### PR TITLE
fix 11th column (again)

### DIFF
--- a/mzgaf2paf.cpp
+++ b/mzgaf2paf.cpp
@@ -222,7 +222,7 @@ size_t mzgaf2paf(const MzGafRecord& gaf_record,
                    << (paf_target_start + leading_deletions) << "\t"
                    << (paf_target_end - leftover_deletions) << "\t"
                    << total_matches << "\t"
-                   << (total_matches + total_insertions + total_deletions - leftover_insertions - leftover_deletions) << "\t"
+                   << (total_matches + total_insertions + total_deletions) << "\t"
                    << parent_record.mapq << "\t" << "cg:Z:";
 
         // and the cigar


### PR DESCRIPTION
Fix bug in 11th column (total bases) where softclips were included even though they were stripped from all other columns.  Could result in negative values...