### PR TITLE
Keep GAF columns 10 and 11 as opt fields in the PAF

### DIFF
--- a/gaf2paf_main.cpp
+++ b/gaf2paf_main.cpp
@@ -228,6 +228,12 @@ static void gaf2paf(const GafRecord& gaf_record, const unordered_map<string, int
             os << "\ttp:" << tp.first << ":" << tp.second;
         }
 
+        // throw in some information about the parent gaf (for downstream filtering)
+        // gm: number of matches in the gaf
+        os << "\tgm:i:" << gaf_record.matches;
+        // gl: block length in the gaf
+        os << "\tgl:i" << gaf_record.block_length;
+
         // output the cigar last
         os << "\tcg:Z:" << cig_string.str() << "\n";
         

--- a/gaf2paf_main.cpp
+++ b/gaf2paf_main.cpp
@@ -232,7 +232,7 @@ static void gaf2paf(const GafRecord& gaf_record, const unordered_map<string, int
         // gm: number of matches in the gaf
         os << "\tgm:i:" << gaf_record.matches;
         // gl: block length in the gaf
-        os << "\tgl:i" << gaf_record.block_length;
+        os << "\tgl:i:" << gaf_record.block_length;
 
         // output the cigar last
         os << "\tcg:Z:" << cig_string.str() << "\n";

--- a/rgfa-split.cpp
+++ b/rgfa-split.cpp
@@ -4,6 +4,7 @@
 #include "rgfa-split.hpp"
 #include "gfakluge.hpp"
 #include "pafcoverage.hpp"
+#include "paf.hpp"
 
 //#define debug 1
 
@@ -658,7 +659,7 @@ int64_t count_small_gap_bases(const vector<string>& toks, int64_t max_gap_as_mat
         if (toks[i].substr(0, 5) == "cg:Z:") {
             for_each_cg(toks[i], [&](const string& val, const string& cat) {
                     int64_t len = stol(val);
-                    if (cat == "M") {
+                    if (cat == "M" || cat == "X" || cat == "=") {
                         if (after_match && running_ins < max_gap_as_match && running_del < max_gap_as_match) {
                             total_gap += running_ins;
                         }


### PR DESCRIPTION
This is in order to allow filters to use this information downstream on the PAF