### PR TITLE
add gaffilter for simple overlap filtering

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ CXXFLAGS := -O3 -Werror=return-type -std=c++14 -ggdb -g -MMD -MP $(PARALLEL_FLAG
 LIB_FLAGS = $(LIBS)
 INC_FLAGS = -I$(CWD)
 
-all: mzgaf2paf gaf2paf pafcoverage rgfa-split paf2lastz rgfa2paf pafmask paf2stable gaf2unstable
+all: mzgaf2paf gaf2paf pafcoverage rgfa-split paf2lastz rgfa2paf pafmask paf2stable gaf2unstable gaffilter
 
 mzgaf2paf: mzgaf2paf.o mzgaf2paf_main.o
 	$(CXX) $(INCLUDE_FLAGS) $(CXXFLAGS) $(CPPFLAGS) -o mzgaf2paf mzgaf2paf_main.o mzgaf2paf.o $(LIB_FLAGS)
@@ -103,6 +103,9 @@ paf2stable_main.o: paf2stable_main.cpp paf2stable.hpp pafcoverage.hpp paf.hpp
 gaf2unstable: gaf2unstable_main.o gafkluge.hpp paf.hpp
 	$(CXX) $(INCLUDE_FLAGS) $(CXXFLAGS) $(CPPFLAGS) -o gaf2unstable gaf2unstable_main.cpp $(INC_FLAGS)
 
+gaffilter: gaffilter_main.o gafkluge.hpp paf.hpp IntervalTree.h
+	$(CXX) $(INCLUDE_FLAGS) $(CXXFLAGS) $(CPPFLAGS) -o gaffilter gaffilter_main.cpp $(INC_FLAGS)
+
 test : all paf2lastz_test pafmask_test
 	cd test && prove -v test.t && prove -v gaf2paf.t
 
@@ -123,4 +126,4 @@ pafmask_test:
 	cd test && prove -v pafmask.t
 
 clean:
-	rm -rf mzgaf2paf main.o mzgaf2paf.o pafcoverage pafcoverage.o pafcoverage_main.o rgfa-split rgfa-split.o rgfa-split_main.o paf2lastz paf2lastz_main.o paf2lastz.o pafmask pafmask_main.o gaf2paf gaf2unstable
+	rm -rf mzgaf2paf main.o mzgaf2paf.o pafcoverage pafcoverage.o pafcoverage_main.o rgfa-split rgfa-split.o rgfa-split_main.o paf2lastz paf2lastz_main.o paf2lastz.o pafmask pafmask_main.o gaf2paf gaf2unstable gaffilter

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ make test
 
 * [gaf2paf](#gaf2paf)
 * [gaf2unstable](#gaf2unstable)
+* [gaffilter](#gaffilter)
 * [paf2lastz](#paf2lastz)
 * [mzgaf2paf](#mzgaf2paf)
 * [rgfa-split](#rgfa-split)
@@ -57,6 +58,16 @@ gaf2unstable 1.gaf -g graph.gfa -o node-lengths.tsv > 1u.gaf
 gaf2paf 1u.gaf -l node-lengths.tsv > 1u.paf
 
 ```
+
+### gaffilter
+
+Filter a GAF so that there are no overlapping query intervals.  It uses simple heuristics.  For each record, keep it if
+* it doesn't overlap anything, or
+* it is primary and only overlaps secondaries, or
+* its mapq is > N * the mapq of any overlap, or
+* its query length is N * the query length of any overlap (and the first two conditions do not apply in reverse from the overlap)
+
+`N` is 2 by default and can be set with `-r`.  
 
 ### paf2lastz
 

--- a/README.md
+++ b/README.md
@@ -65,9 +65,11 @@ Filter a GAF so that there are no overlapping query intervals.  It uses simple h
 * it doesn't overlap anything, or
 * it is primary and only overlaps secondaries, or
 * its mapq is > N * the mapq of any overlap, or
-* its query length is N * the query length of any overlap (and the first two conditions do not apply in reverse from the overlap)
+* its block length is N * the block length of any overlap (and the first two conditions do not apply in reverse from the overlap)
 
-`N` is 2 by default and can be set with `-r`.  
+`N` is 2 by default and can be set with `-r`.
+
+This tool can also run on PAFs (expecting to use the original GAF block length stored in a "gl" tag) by adding the `-p` option. In practice, this will perform a more fine-grained filter and should remove fewer alignments. 
 
 ### paf2lastz
 

--- a/gaffilter_main.cpp
+++ b/gaffilter_main.cpp
@@ -37,16 +37,16 @@ static bool dominates(const GafRecord& gaf1, const GafRecord& gaf2, double ratio
     } else if (primary2 && !primary1) {
         return false;
     }
-    if ((double)gaf1.block_length / ((double)gaf2.block_length + 0.000001) >= ratio) {
-        return true;
-    } else if ((double)gaf2.block_length / ((double)gaf1.block_length + 0.000001) >= ratio) {
-        return false;
-    }
     if ((double)gaf1.mapq / ((double)gaf2.mapq + 0.000001) >= ratio) {
         return true;
     } else if ((double)gaf2.mapq / ((double)gaf1.mapq + 0.000001) >= ratio) {
         return false;
     }
+    if ((double)gaf1.block_length / ((double)gaf2.block_length + 0.000001) >= ratio) {
+        return true;
+    } else if ((double)gaf2.block_length / ((double)gaf1.block_length + 0.000001) >= ratio) {
+        return false;
+    }    
     return false;
 }
 

--- a/gaffilter_main.cpp
+++ b/gaffilter_main.cpp
@@ -27,7 +27,7 @@ static void help(char** argv) {
     cerr << "usage: " << argv[0] << " [options] <gaf> > output.gaf" << endl
          << "Filter GAF record if its query interval overlaps another query interval and\n"
          << "  1) the record is secondary and the overlapping record is primary or\n"
-         << "  1) the record's MAPQ is lower than {ratio, see -r} times the overlapping record's MAPQ or\n"
+         << "  2) the record's MAPQ is lower than {ratio, see -r} times the overlapping record's MAPQ or\n"
          << "  3) the record's block length is less than {ratio, see -r} times larger than the overlapping record's block length (and its MAPQ isn't higher)" << endl
          << endl
          << "options: " << endl
@@ -153,7 +153,8 @@ int main(int argc, char** argv) {
             parse_gaf_record(line_buffer, gaf_record);
         }
         gaf_records.push_back(gaf_record);
-    }    
+    }
+    cerr << "[gaffilter]: Loaded " << gaf_records.size() << (is_paf ? "PAF" : "GAF") << " records" << endl;
 
     // make an interval tree for each query sequence
     unordered_map<string, vector<GafInterval>> gaf_intervals;
@@ -166,6 +167,7 @@ int main(int argc, char** argv) {
         gaf_trees[qi.first] = new GafIntervalTree(qi.second);
     }
     gaf_intervals.clear();
+    cerr << "[gaffilter]: Constructed interval trees" << endl;
 
     // test if one record "dominates" another, using primary/secondary, mapq, block length in that order
     function<bool(const GafRecord&, const GafRecord&)> dominates = [&](const GafRecord& gaf1, const GafRecord& gaf2) {

--- a/gaffilter_main.cpp
+++ b/gaffilter_main.cpp
@@ -132,10 +132,6 @@ int main(int argc, char** argv) {
         if (is_paf) {
             PafLine paf_record = parse_paf_line(line_buffer);
             paf_records.push_back(paf_record);
-            if (!paf_record.opt_fields.count("gl")) {
-                cerr << "[gaffilter] error: \"gl\" optional tag required to process PAF" << endl;
-                return 1;
-            }            
             // just copy what we (might) need
             gaf_record.query_name = paf_record.query_name;
             gaf_record.query_length = paf_record.query_len;
@@ -143,7 +139,11 @@ int main(int argc, char** argv) {
             gaf_record.query_end = paf_record.query_end;
             gaf_record.strand = paf_record.strand;
             gaf_record.mapq = paf_record.mapq;
-            gaf_record.block_length = stol(paf_record.opt_fields.at("gl").second);
+            if (paf_record.opt_fields.count("gl")) {
+                gaf_record.block_length = stol(paf_record.opt_fields.at("gl").second);
+            } else {
+                gaf_record.block_length = paf_record.num_bases;
+            }
             if (paf_record.opt_fields.count("tp")) {
                 gaf_record.opt_fields["tp"] = paf_record.opt_fields.at("tp");
             }

--- a/gaffilter_main.cpp
+++ b/gaffilter_main.cpp
@@ -1,0 +1,191 @@
+/*
+  Filter GAF records according to query overlap
+ */
+
+#include <unistd.h>
+#include <getopt.h>
+#include <fstream>
+#include <unordered_map>
+#include <algorithm>
+#include <list>
+#include <cassert>
+
+#include "gafkluge.hpp"
+#include "paf.hpp"
+#include "IntervalTree.h"
+
+//#define debug
+
+using namespace std;
+using namespace gafkluge;
+
+typedef IntervalTree<int64_t, const GafRecord*> GafIntervalTree;
+typedef GafIntervalTree::interval GafInterval;
+
+
+static void help(char** argv) {
+    cerr << "usage: " << argv[0] << " [options] <gaf> > output.gaf" << endl
+         << "Filter GAF record if its query interval overlaps another query interval and\n"
+         << "  1) the record is secondary and the overlapping record is primary or\n"
+         << "  1) the record's MAPQ is lower than {ratio, see -r} times the overlapping record's MAPQ or\n "
+         << "  3) the record's query interval is less than {ratio, see -r} times larger than the overlapping record's query interval" << endl
+         << endl
+         << "options: " << endl
+         << "    -r, --ratio N      If two query blocks overlap, and one is Nx bigger than the other, the bigger one is kept (otherwise both deleted) [2]" << endl;
+}    
+
+int main(int argc, char** argv) {
+
+    double ratio = 2.;
+    
+    int c;
+    optind = 1; 
+    while (true) {
+
+        static const struct option long_options[] = {
+            {"help", no_argument, 0, 'h'},
+            {"ratio", required_argument, 0, 'r'},
+            {0, 0, 0, 0}
+        };
+
+        int option_index = 0;
+
+        c = getopt_long (argc, argv, "h:r:",
+                         long_options, &option_index);
+
+        // Detect the end of the options.
+        if (c == -1)
+            break;
+
+        switch (c)
+        {
+        case 'r':
+            ratio = stof(optarg);
+            break;
+        case 'h':
+        case '?':
+            /* getopt_long already printed an error message. */
+            help(argv);
+            exit(1);
+            break;
+        default:
+            abort ();
+        }
+    }
+
+    if (argc <= 1) {
+        help(argv);
+        return 1;
+    }
+
+    // Parse the positional argument
+    if (optind >= argc) {
+        cerr << "[gaffilter] error: too few arguments" << endl;
+        help(argv);
+        return 1;
+    }
+    
+    string gaf_path = argv[optind++];
+    
+    // open the gaf file
+    ifstream in_file;
+    istream* in_stream;
+    if (gaf_path == "-") {
+        in_stream = &cin;
+    } else {
+        in_file.open(gaf_path);
+        if (!in_file) {
+            cerr << "[gaffilter] error: unable to open input: " << gaf_path << endl;
+            return 1;
+        }
+        in_stream = &in_file;
+    }
+
+    // just load the gaf into memory
+    vector<GafRecord> gaf_records;
+    string line_buffer;
+    while (getline(*in_stream, line_buffer)) {
+        if (line_buffer[0] == '*') {
+            // skip -S stuff
+            continue;
+        }
+        GafRecord gaf_record;
+        parse_gaf_record(line_buffer, gaf_record);
+        gaf_records.push_back(gaf_record);
+    }    
+
+    // make an interval tree for each query sequence
+    unordered_map<string, vector<GafInterval>> gaf_intervals;
+    for (const auto& gaf_record : gaf_records) {
+        GafInterval gaf_interval(gaf_record.query_start, gaf_record.query_end - 1, &gaf_record);
+        gaf_intervals[gaf_record.query_name].push_back(gaf_interval);
+    }
+    unordered_map<string, GafIntervalTree*> gaf_trees;
+    for (const auto& qi : gaf_intervals) {
+        gaf_trees[qi.first] = new GafIntervalTree(qi.second);
+    }
+    gaf_intervals.clear();
+
+
+    int64_t filter_count = 0;
+    int64_t filter_len_count = 0;
+
+    // simple algorithm:
+    // for each record, scan it's overlaps and flag it if it finds anything
+    // that overlaps that isn't ratio X smaller.
+    // this is a really inefficient in worst-case (where everything overlaps) but that's not at all what we expect
+    for (int64_t i = 0; i < gaf_records.size(); ++i) {
+        bool is_filtered = false;
+        int64_t query_len = gaf_records[i].query_end - gaf_records[i].query_start;
+        bool is_primary = !gaf_records[i].opt_fields.count("tp") || gaf_records[i].opt_fields.at("tp").second == "P";
+        vector<GafInterval> overlapping = gaf_trees[gaf_records[i].query_name]->findOverlapping(
+            gaf_records[i].query_start, gaf_records[i].query_end);
+        for (const auto& ogi : overlapping) {
+            if (ogi.value != &gaf_records[i]) {
+                bool overlap_primary = !ogi.value->opt_fields.count("tp") || ogi.value->opt_fields.at("tp").second == "P";
+                int64_t overlap_len = ogi.value->query_end - ogi.value->query_start;
+                double orat = (double)query_len / ((double)overlap_len + 0.000001);
+                double mrat = (double)gaf_records[i].mapq / ((double)ogi.value->mapq + 0.000001);
+                // primary / secondary comparison takes priority
+                if (overlap_primary && !is_primary) {
+#ifdef debug
+                    cerr << "filtering record " << i << "\n " << gaf_records[i] << "\ndue to primary overlap with\n "
+                         << *ogi.value << endl;
+#endif                    
+                    is_filtered = true;
+                } else {
+                    // next is mapq
+                    if (1. / mrat >= ratio) {
+#ifdef debug
+                        cerr << "filtering record " << i << "\n " << gaf_records[i] << "\n because its mapq is dominiated by " << (1./mrat) << " by\n "
+                         << *ogi.value << endl;
+#endif                                            
+                        is_filtered = true;
+                        // then interval length
+                    } else if (mrat <= ratio && 1. / orat >= ratio) {
+#ifdef debug
+                        cerr << "filtering record " << i << "\n " << gaf_records[i] << "\n because its query interval is dominiated by " << (1./orat) << " by\n "
+                         << *ogi.value << endl;
+#endif                    
+                        is_filtered = true;
+                    }
+                }
+                if (is_filtered) {
+                    ++filter_count;
+                    filter_len_count += query_len;
+                    break;
+                }
+            }
+        }
+        if (!is_filtered) {
+            cout << gaf_records[i] << "\n";
+        }
+    }
+
+    for (auto qt : gaf_trees) {
+        delete qt.second;
+    }
+    
+    cerr << "[gaffilter]: filtered " << filter_count << " / " << gaf_records.size() << ". total query intervals filtered: " << filter_len_count << endl;
+    return 0;
+}

--- a/gaffilter_main.cpp
+++ b/gaffilter_main.cpp
@@ -230,7 +230,11 @@ int main(int argc, char** argv) {
             cout << print_record(gaf_records[i]) << "\n";
         } else {
             ++filter_count;
-            filter_len_count += gaf_records[i].block_length;
+            if (is_paf) {
+                filter_len_count += paf_records[i].num_bases;
+            } else {
+                filter_len_count += gaf_records[i].block_length;
+            }
 #ifdef debug
             cerr << "\nfiltering record " << i << " (" << &gaf_records[i] << ") because it doesn't dominate its "
                  << (overlapping.size() - 1) << " overlaps\n  " << print_record(gaf_records[i]) << endl;

--- a/gaffilter_main.cpp
+++ b/gaffilter_main.cpp
@@ -211,8 +211,13 @@ int main(int argc, char** argv) {
     // this is a really inefficient in worst-case (where everything overlaps) but that's not at all what we expect
     for (int64_t i = 0; i < gaf_records.size(); ++i) {
         bool is_dominant = true;
+        int64_t end_point = gaf_records[i].query_end;
+        if (end_point > gaf_records[i].query_start) {
+            // interval tree expects closed coordinates.  but it also expects the end point >= start point
+            --end_point;
+        }
         vector<GafInterval> overlapping = gaf_trees[gaf_records[i].query_name]->findOverlapping(
-            gaf_records[i].query_start, gaf_records[i].query_end);
+            gaf_records[i].query_start, end_point);        
         for (const auto& ogi : overlapping) {
             if (ogi.value != &gaf_records[i]) {
                 is_dominant = is_dominant && dominates(gaf_records[i], *ogi.value);


### PR DESCRIPTION
`mzgaf2paf` has a `-o` option that filtered out GAF lines whose query intervals overlapped.  This functionality was lost when switching over the minigraph-with-cigars via `gaf2paf`, but I now suspect it was more important than I thought.  

This PR adds `gaffilter` which is a standalone tool to filter out query overlaps.  It uses a slightly different heuristic though, and when several records overlaps, uses primary / secondary flags, mapq, and length (in that order of preference) to see if one interval is chosen. 