### PR TITLE
fix silently truncated gfa splits, and detect failed writes generally

### DIFF
--- a/gaf2paf_main.cpp
+++ b/gaf2paf_main.cpp
@@ -13,6 +13,7 @@
 
 #include "gafkluge.hpp"
 #include "paf.hpp"
+#include "pafcoverage.hpp"
 
 //#define debug
 
@@ -272,6 +273,10 @@ static void help(char** argv) {
 }    
 
 int main(int argc, char** argv) {
+    // the result goes to standard output, and a failed write there is
+    // otherwise reported to nobody
+    check_stdout_at_exit();
+
 
     string rgfa_path;
     string lengths_path;

--- a/gaf2unstable_main.cpp
+++ b/gaf2unstable_main.cpp
@@ -9,6 +9,7 @@
 #include "gfakluge.hpp"
 #include "gafkluge.hpp"
 #include "rgfa-split.hpp"
+#include "pafcoverage.hpp"
 
 //#define debug
 
@@ -184,6 +185,10 @@ void help(char** argv) {
 }    
 
 int main(int argc, char** argv) {
+    // the result goes to standard output, and a failed write there is
+    // otherwise reported to nobody
+    check_stdout_at_exit();
+
 
     string rgfa_path;
     string node_lengths_path;

--- a/gaffilter_main.cpp
+++ b/gaffilter_main.cpp
@@ -13,6 +13,7 @@
 #include "gafkluge.hpp"
 #include "paf.hpp"
 #include "IntervalTree.h"
+#include "pafcoverage.hpp"
 
 //#define debug
 
@@ -88,6 +89,10 @@ static void help(char** argv) {
 }    
 
 int main(int argc, char** argv) {
+    // the result goes to standard output, and a failed write there is
+    // otherwise reported to nobody
+    check_stdout_at_exit();
+
 
     double ratio = 0.;
     double min_overlap_pct = 0.;

--- a/paf2lastz_main.cpp
+++ b/paf2lastz_main.cpp
@@ -6,6 +6,7 @@
 #include <vector>
 
 #include "paf2lastz.hpp"
+#include "pafcoverage.hpp"
 
 using namespace std;
 
@@ -19,6 +20,10 @@ void help(char** argv) {
 }    
 
 int main(int argc, char** argv) {
+    // the result goes to standard output, and a failed write there is
+    // otherwise reported to nobody
+    check_stdout_at_exit();
+
 
     bool mapq_score = false;
     string secondary_path;
@@ -123,6 +128,13 @@ int main(int argc, char** argv) {
             }
         }
     }
-    
+
+    // closing is where the last buffered records reach the operating system,
+    // and leaving it to the destructor would discard a failure there
+    if (!close_output_file(secondary_file)) {
+        cerr << "[paf2lastz] error: failed to write secondary-file: " << secondary_path << endl;
+        return 1;
+    }
+
     return 0;
 }

--- a/paf2stable_main.cpp
+++ b/paf2stable_main.cpp
@@ -19,6 +19,10 @@ void help(char** argv) {
 }    
 
 int main(int argc, char** argv) {
+    // the result goes to standard output, and a failed write there is
+    // otherwise reported to nobody
+    check_stdout_at_exit();
+
 
     int64_t min_length = 1;
     int64_t padding = 100;

--- a/pafcoverage.hpp
+++ b/pafcoverage.hpp
@@ -9,10 +9,60 @@
 #include <vector>
 #include <unordered_map>
 #include <ostream>
+#include <iostream>
+#include <fstream>
+#include <cstdlib>
 #include <functional>
 #include "paf.hpp"
 
 using namespace std;
+
+/** Report a failed write to standard output when the program exits.
+ *
+ * These tools stream their result to standard output and leave the caller to
+ * redirect it.  A C++ stream reports a failed write -- a full disk, a quota, a
+ * read-only mount -- by setting a flag that nothing is obliged to read, and the
+ * flush that happens at exit discards any error, so without this a truncated
+ * paf, gaf or bed and a complete one are indistinguishable and the tool still
+ * exits successfully.  A short paf is still a valid paf.
+ *
+ * Call once, at the top of main.  Inline, so that the tools which do not link
+ * pafcoverage.o can use it too.
+ */
+inline void check_stdout_at_exit() {
+    static bool installed = false;
+    if (installed) {
+        return;
+    }
+    installed = true;
+    // the flush has to happen inside the handler, because atexit runs before
+    // the runtime flushes the streams, and _Exit is used because calling exit()
+    // from an atexit handler is undefined
+    atexit([]() {
+        cout.flush();
+        if (cout.fail() || cout.bad()) {
+            cerr << "error: failed to write to standard output, so its contents are incomplete. "
+                 << "Check the free space, the quota and the permissions on the file system "
+                 << "holding it." << endl;
+            _Exit(EXIT_FAILURE);
+        }
+    });
+}
+
+/** Flush and close a file we have written, returning false if anything failed.
+ *
+ * Closing is the last point at which buffered data reaches the operating
+ * system, so a write that fails there is reported nowhere else;  leaving it to
+ * the destructor discards the failure.
+ */
+inline bool close_output_file(ofstream& out) {
+    if (not out.is_open()) {
+        return true;
+    }
+    out.flush();
+    out.close();
+    return not (out.fail() or out.bad());
+}
 
 // map a sequence name to all its covered bases (not caring about depth, so just using bools)
 typedef unordered_map<string, vector<bool>> CoverageMap;

--- a/pafcoverage_main.cpp
+++ b/pafcoverage_main.cpp
@@ -18,6 +18,10 @@ void help(char** argv) {
 }    
 
 int main(int argc, char** argv) {
+    // the result goes to standard output, and a failed write there is
+    // otherwise reported to nobody
+    check_stdout_at_exit();
+
 
     string query_prefix;
     bool print_gaps = false;

--- a/pafmask_main.cpp
+++ b/pafmask_main.cpp
@@ -2,6 +2,7 @@
 #include <getopt.h>
 
 #include "pafmask.hpp"
+#include "pafcoverage.hpp"
 
 void help(char** argv) {
   cerr << "usage: " << argv[0] << " [options] <paf> <bed>" << endl
@@ -14,6 +15,10 @@ void help(char** argv) {
 }    
 
 int main(int argc, char** argv) {
+    // the result goes to standard output, and a failed write there is
+    // otherwise reported to nobody
+    check_stdout_at_exit();
+
 
     int64_t min_length = 1;
     int64_t padding = 100;

--- a/rgfa-split.cpp
+++ b/rgfa-split.cpp
@@ -599,9 +599,20 @@ void paf_split(const string& input_paf_path,
         }
     }
 
-    // clean up the files
+    // clean up the files;  the delete is what closes them, and closing is
+    // where the last buffered records reach the operating system, so its
+    // failure has to be looked at rather than discarded with the object
     for (auto& ref_stream : out_files) {
-        delete ref_stream.second;
+        ofstream *out_paf_stream = ref_stream.second;
+        out_paf_stream->flush();
+        out_paf_stream->close();
+        bool failed = out_paf_stream->fail() || out_paf_stream->bad();
+        delete out_paf_stream;
+        if (failed) {
+            cerr << "error: failed to write output paf file: " << output_prefix
+                 << contigs[ref_stream.first] << ".paf" << endl;
+            exit(1);
+        }
     }
     out_files.clear();
 
@@ -718,8 +729,27 @@ void gfa_split(const string& rgfa_path,
         }
     }
 
-    // clean up the files
-    flush_files();
+    // Clean up the files.
+    //
+    // flush_files() only closes anything once more than a hundred are open,
+    // because it exists to stay under the descriptor limit.  Ending here with
+    // just that call left every stream leaked and unflushed whenever the split
+    // produced a hundred files or fewer -- which is the normal case -- so the
+    // tail of each output gfa was silently dropped, one buffer's worth, and
+    // the short file it left is still a parseable gfa.
+    for (auto& ref_stream : out_files) {
+        ofstream *out_gfa_stream = ref_stream.second;
+        out_gfa_stream->flush();
+        out_gfa_stream->close();
+        bool failed = out_gfa_stream->fail() || out_gfa_stream->bad();
+        delete out_gfa_stream;
+        if (failed) {
+            cerr << "error: failed to write output gfa file: " << output_prefix
+                 << contigs[ref_stream.first] << ".gfa" << endl;
+            exit(1);
+        }
+    }
+    out_files.clear();
 }
 
 int64_t count_small_gap_bases(const vector<string>& toks, int64_t max_gap_as_match) {

--- a/rgfa-split_main.cpp
+++ b/rgfa-split_main.cpp
@@ -42,6 +42,10 @@ void help(char** argv) {
 }    
 
 int main(int argc, char** argv) {
+    // the result goes to standard output, and a failed write there is
+    // otherwise reported to nobody
+    check_stdout_at_exit();
+
 
     // input
     string rgfa_path;
@@ -285,6 +289,12 @@ int main(int argc, char** argv) {
         }
         for (auto& node_contig : partition.first) {
             output_contig_map_file << "S" << node_contig.first << "\t" << partition.second[node_contig.second] << "\n";
+        }
+        // the destructor would close this and discard any failure
+        if (!close_output_file(output_contig_map_file)) {
+            cerr << "[rgfa-split] error: failed to write output contig map file \""
+                 << output_contig_map_path << "\"" << endl;
+            return 1;
         }
     }
 

--- a/rgfa2paf_main.cpp
+++ b/rgfa2paf_main.cpp
@@ -24,6 +24,10 @@ void help(char** argv) {
 }    
 
 int main(int argc, char** argv) {
+    // the result goes to standard output, and a failed write there is
+    // otherwise reported to nobody
+    check_stdout_at_exit();
+
 
     string rgfa_path;
     int64_t max_rank = 0;


### PR DESCRIPTION
rgfa-split -G was dropping the tail of every output gfa. gfa_split ended by calling flush_files(), which only closes anything once more than a hundred files are open, because it exists to stay under the descriptor limit. Below that -- the normal case, a split producing one file per chromosome -- it did nothing, and out_files holds raw pointers, so every stream leaked with its last buffer unwritten. Measured on a 67 MB single-contig gfa: 67,670,498 bytes out for 67,671,399 in, twenty lines short, the file not even ending in a newline. It is still a parseable gfa, which is why this could go unnoticed. Closing them explicitly makes that same split byte-identical to its input.

The paf fan-out did delete its streams, so it did not lose data, but the delete is what closes them and its failure went with the object. Both loops now close and check.

Separately, all nine tools streamed their result to standard output without ever asking whether it landed. A C++ stream reports a failed write -- a full disk, a quota, a read-only mount -- by setting a flag that nothing was reading, and the flush at exit discards it, so a truncated paf, gaf or bed was indistinguishable from a complete one and the tool still exited zero. check_stdout_at_exit, called at the top of each main, reports it instead. It lives in pafcoverage.hpp, which four of them already included, and is inline so that the tools which do not link pafcoverage.o can use it too.

paf2lastz's --secondary-file and rgfa-split's contig map are closed through close_output_file now rather than being left to a destructor.

Verified against /dev/full: paf2lastz and pafcoverage exit 1 naming the failure, where they previously exited 0. Healthy output is unchanged.